### PR TITLE
Fix typos

### DIFF
--- a/data/org.gnome.Solanum.appdata.xml.in.in
+++ b/data/org.gnome.Solanum.appdata.xml.in.in
@@ -41,7 +41,7 @@
         <p>The 3.0.0 release of Solanum brings new preferences, updated translations, and minor bug fixes.</p>
         <ul>
           <li>Solanum now has preferences to adjust the various timer lengths, as well as how many laps to go through before a long break.</li>
-          <li>New and updated translations for the German, Spanish, Slovenian, Dutch, Romanian, Chinese (China), Korean, Galician, Brazilian Portuguese, Ukranian, Swedish, Polish, Czech, and Finish languages.</li>
+          <li>New and updated translations for the German, Spanish, Slovenian, Dutch, Romanian, Chinese (China), Korean, Galician, Brazilian Portuguese, Ukrainian, Swedish, Polish, Czech, and Finish languages.</li>
         </ul>
       </description>
     </release>
@@ -61,7 +61,7 @@
         <ul>
           <li>The UI has been ported to GTK 4, making Solanum one of the first GTK 4 apps.</li>
           <li>Support for translations has been added.</li>
-          <li>Added translations for French, Spanish, Swedish, Slovenian, Italian, Indonesian, Polish, Finnish, Brazilian Portuguese, Basque, Czech, Ukranian, and British English</li>
+          <li>Added translations for French, Spanish, Swedish, Slovenian, Italian, Indonesian, Polish, Finnish, Brazilian Portuguese, Basque, Czech, Ukrainian, and British English</li>
           <li>Fix: The timer state is properly updated when using the skip button.</li>
         </ul>
       </description>

--- a/src/main.rs
+++ b/src/main.rs
@@ -31,7 +31,7 @@ use crate::app::SolanumApplication;
 
 // Entry point for the application
 fn main() {
-    // Initiialize gtk, gstreamer, and libhandy.
+    // Initialize gtk, gstreamer, and libhandy.
     gtk::init().expect("Failed to initialize gtk");
     gstreamer::init().expect("Failed to initialize gstreamer");
     libadwaita::init();

--- a/src/window.rs
+++ b/src/window.rs
@@ -298,7 +298,7 @@ impl SolanumWindow {
         player.play();
     }
 
-    fn send_notifcation(&self, lap_type: LapType) {
+    fn send_notification(&self, lap_type: LapType) {
         if !self.is_active() {
             let notif = gio::Notification::new(&i18n("Solanum"));
             // Set notification text based on lap type
@@ -351,7 +351,7 @@ impl SolanumWindow {
         self.update_lap(next_lap);
 
         if notify {
-            self.send_notifcation(next_lap);
+            self.send_notification(next_lap);
         }
     }
 }


### PR DESCRIPTION
Found via `codespell -S po -L crate`.